### PR TITLE
fix unused variable warning

### DIFF
--- a/mobject.c
+++ b/mobject.c
@@ -193,6 +193,7 @@ static void
 mnone_free(const struct mnone *o)
 {
 	/* Do nothing - mnone is a singleton */
+	(void)o;
 }
 
 static void


### PR DESCRIPTION
This fixes a warning because o is not used yet.

```
mobject.c: In function ‘mnone_free’:
mobject.c:193:32: warning: unused parameter ‘o’ [-Wunused-parameter]
  193 | mnone_free(const struct mnone *o)
      |            ~~~~~~~~~~~~~~~~~~~~^
```

By the way, thanks for this library. I was searching for a text processing for long and it's amazing. It's a shame it's not enough popular!