### PR TITLE
be more pedantic

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -16,8 +16,8 @@
 
 /* $Id$ */
 
-#ifndef _MTEMPLATE_COMPAT_H
-#define _MTEMPLATE_COMPAT_H
+#ifndef MTEMPLATE_COMPAT_H
+#define MTEMPLATE_COMPAT_H
 
 #include <sys/types.h>
 
@@ -47,4 +47,4 @@ size_t
 strlcat(char *dst, const char *src, size_t siz);
 #endif /* defined(__linux__) */
 
-#endif /* _MTEMPLATE_COMPAT_H */
+#endif /* MTEMPLATE_COMPAT_H */

--- a/mobject.h
+++ b/mobject.h
@@ -18,8 +18,8 @@
 
 /* Simple generic object system, loosely modelled on Python's */
 
-#ifndef _MOBJECT_H
-#define _MOBJECT_H
+#ifndef MOBJECT_H
+#define MOBJECT_H
 
 #include <sys/types.h>
 #include <stdint.h>
@@ -405,4 +405,4 @@ int mnamespace_lookup(struct mobject *ns, char *location, struct mobject **obj,
 int mnamespace_set(struct mobject *ns, char *location, struct mobject *obj,
     char *ebuf, size_t elen);
 
-#endif /* _MOBJECT_H */
+#endif /* MOBJECT_H */

--- a/mtemplate.h
+++ b/mtemplate.h
@@ -18,8 +18,8 @@
 
 /* Simple template system */
 
-#ifndef _MTEMPLATE_H
-#define _MTEMPLATE_H
+#ifndef MTEMPLATE_H
+#define MTEMPLATE_H
 
 #include <sys/types.h>
 #include <stdio.h>
@@ -82,4 +82,4 @@ int
 mtemplate_run_cb(struct mtemplate *tmpl, struct mobject *ns, char *ebuf,
     size_t elen, int (*out_cb)(const char *, void *), void *out_ctx);
 
-#endif /* _MTEMPLATE_H */
+#endif /* MTEMPLATE_H */

--- a/strstcpy.h
+++ b/strstcpy.h
@@ -19,7 +19,7 @@
 
 /* $Id: strstcpy.h,v 1.1 2007/04/02 08:55:06 djm Exp $ */
 
-#ifndef _STRSTCPY_H
+#ifndef STRSTCPY_H
 #include <sys/types.h>
 
 /*
@@ -31,4 +31,4 @@
 size_t
 strstcpy(char *dst, const char *src, size_t len, const char *stopchars);
 
-#endif /* _STRSTCPY_H */
+#endif /* STRSTCPY_H */

--- a/sys-queue.h
+++ b/sys-queue.h
@@ -32,8 +32,8 @@
  *	@(#)queue.h	8.5 (Berkeley) 8/20/94
  */
 
-#ifndef	_SYS_QUEUE_H_
-#define	_SYS_QUEUE_H_
+#ifndef	SYS_QUEUE_H
+#define	SYS_QUEUE_H
 
 /*
  * This file defines five types of data structures: singly-linked lists, 
@@ -524,4 +524,4 @@ struct {								\
 	_Q_INVALIDATE((elm)->field.cqe_next);				\
 } while (0)
 
-#endif	/* !_SYS_QUEUE_H_ */
+#endif	/* !SYS_QUEUE_H */

--- a/vis.h
+++ b/vis.h
@@ -32,8 +32,8 @@
  *	@(#)vis.h	5.9 (Berkeley) 4/3/91
  */
 
-#ifndef _VIS_H_
-#define	_VIS_H_
+#ifndef VIS_H
+#define	VIS_H
 
 /*
  * to select alternate encoding format
@@ -84,4 +84,4 @@ int	unvis(char *, char, int *, int);
 ssize_t strnunvis(char *, const char *, size_t)
 		/* __attribute__ ((__bounded__(__string__,1,3))) */;
 
-#endif /* !_VIS_H_ */
+#endif /* !VIS_H */


### PR DESCRIPTION
Identifier starting with an underscore and immediately followed by a capital letter is reserved per C standard. This changes avoid that.